### PR TITLE
Add missing `--ut` in help_text

### DIFF
--- a/src/fprime/util/help_text.py
+++ b/src/fprime/util/help_text.py
@@ -127,9 +127,9 @@ Examples:
   cd Ref/SignalGen
   {EXECUTABLE} build
 
-  -- Build Reg/SignalGen UTs --
+  -- Build Ref/SignalGen UTs --
   cd Ref/SignalGen
-  {EXECUTABLE} build
+  {EXECUTABLE} build --ut
 
 """,
     "impl": f"""{EXECUTABLE} impl ({VERSION}): Generate fprime implementation templates.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/1621

## Rationale


## Testing/Review Recommendations

None

## Future Work

None
